### PR TITLE
Added update user dto to fix bugs

### DIFF
--- a/src/main/java/com/cag/cagbackendapi/constants/Constants.kt
+++ b/src/main/java/com/cag/cagbackendapi/constants/Constants.kt
@@ -2,6 +2,7 @@ package com.cag.cagbackendapi.constants
 
 import com.cag.cagbackendapi.dtos.UserRegistrationDto
 import com.cag.cagbackendapi.dtos.UserDto
+import com.cag.cagbackendapi.dtos.UserUpdateDto
 import java.util.*
 
 object RestErrorMessages {
@@ -31,7 +32,7 @@ object LoggerMessages {
     fun LOG_SAVE_USER(userRegistration: UserRegistrationDto): String {
         return "Save user: $userRegistration"
     }
-    fun LOG_UPDATE_USER(userDto: UserDto): String {
+    fun LOG_UPDATE_USER(userDto: UserUpdateDto): String {
         return "Update user: $userDto"
     }
     fun GET_USER(userId: UUID): String {

--- a/src/main/java/com/cag/cagbackendapi/controllers/UserController.java
+++ b/src/main/java/com/cag/cagbackendapi/controllers/UserController.java
@@ -2,6 +2,7 @@ package com.cag.cagbackendapi.controllers;
 
 import com.cag.cagbackendapi.dtos.UserRegistrationDto;
 import com.cag.cagbackendapi.dtos.UserDto;
+import com.cag.cagbackendapi.dtos.UserUpdateDto;
 import com.cag.cagbackendapi.services.user.impl.UserService;
 import com.cag.cagbackendapi.services.validation.impl.ValidationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +40,7 @@ public class UserController {
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<UserDto> updateUser(
             @RequestHeader("authKey") String authKey,
-            @RequestBody UserDto userRequestDto,
+            @RequestBody UserUpdateDto userRequestDto,
             @PathVariable("userId") String userId
     ){
         this.validationService.validateAuthKey(authKey);

--- a/src/main/java/com/cag/cagbackendapi/daos/UserDaoI.kt
+++ b/src/main/java/com/cag/cagbackendapi/daos/UserDaoI.kt
@@ -2,11 +2,12 @@ package com.cag.cagbackendapi.daos;
 
 import com.cag.cagbackendapi.dtos.UserRegistrationDto
 import com.cag.cagbackendapi.dtos.UserDto
+import com.cag.cagbackendapi.dtos.UserUpdateDto
 import java.util.*
 
 interface UserDaoI {
     fun saveUser(userRegistrationDto: UserRegistrationDto): UserDto
-    fun updateUser(userId: UUID, userDto: UserDto): UserDto?
+    fun updateUser(userId: UUID, userUpdateDto: UserUpdateDto): UserDto?
     fun getUser(userUUID: UUID): UserDto?
     fun deleteUser(userUUID: UUID): UserDto?
 

--- a/src/main/java/com/cag/cagbackendapi/daos/impl/UserDao.kt
+++ b/src/main/java/com/cag/cagbackendapi/daos/impl/UserDao.kt
@@ -7,6 +7,7 @@ import com.cag.cagbackendapi.constants.LoggerMessages.LOG_UPDATE_USER
 import com.cag.cagbackendapi.daos.UserDaoI
 import com.cag.cagbackendapi.dtos.UserRegistrationDto
 import com.cag.cagbackendapi.dtos.UserDto
+import com.cag.cagbackendapi.dtos.UserUpdateDto
 import com.cag.cagbackendapi.entities.UserEntity
 import com.cag.cagbackendapi.repositories.UserRepository
 import org.modelmapper.ModelMapper
@@ -40,18 +41,14 @@ class UserDao : UserDaoI {
         return userEntity.toDto()
     }
 
-    private fun userDtoToEntity(userRegistrationDto: UserRegistrationDto): UserEntity {
-        return modelMapper.map(userRegistrationDto, UserEntity::class.java)
-    }
-
-    override fun updateUser(userId: UUID, userDto: UserDto): UserDto? {
-        logger.info(LOG_UPDATE_USER(userDto))
+    override fun updateUser(userId: UUID, userUpdateDto: UserUpdateDto): UserDto? {
+        logger.info(LOG_UPDATE_USER(userUpdateDto))
 
         val userEntity = userRepository.getByUserId(userId) ?: return null
 
-        userEntity.setFirstName(userDto.first_name)
-        userEntity.setLastName(userDto.last_name)
-        userEntity.setEmailJava(userDto.email)
+        userEntity.setFirstName(userUpdateDto.first_name)
+        userEntity.setLastName(userUpdateDto.last_name)
+        userEntity.setEmailJava(userUpdateDto.email)
 
         val userResponseEntity = userRepository.save(userEntity)
 
@@ -65,5 +62,9 @@ class UserDao : UserDaoI {
         userRepository.deleteById(userUUID)
         return deleteUserEntity.toDto()
 
+    }
+
+    private fun userDtoToEntity(userRegistrationDto: UserRegistrationDto): UserEntity {
+        return modelMapper.map(userRegistrationDto, UserEntity::class.java)
     }
 }

--- a/src/main/java/com/cag/cagbackendapi/dtos/UserUpdateDto.kt
+++ b/src/main/java/com/cag/cagbackendapi/dtos/UserUpdateDto.kt
@@ -1,0 +1,6 @@
+package com.cag.cagbackendapi.dtos;
+
+data class UserUpdateDto(
+    var first_name: String?,
+    var last_name: String?,
+    var email: String?)

--- a/src/main/java/com/cag/cagbackendapi/services/user/UserServiceI.java
+++ b/src/main/java/com/cag/cagbackendapi/services/user/UserServiceI.java
@@ -2,10 +2,11 @@ package com.cag.cagbackendapi.services.user;
 
 import com.cag.cagbackendapi.dtos.UserRegistrationDto;
 import com.cag.cagbackendapi.dtos.UserDto;
+import com.cag.cagbackendapi.dtos.UserUpdateDto;
 
 public interface UserServiceI {
     UserDto registerUser(UserRegistrationDto userRegistrationDto);
     UserDto getByUserId(String userId);
-    UserDto updateUser(String userId, UserDto userRequestDto);
+    UserDto updateUser(String userId, UserUpdateDto userUpdateDto);
     UserDto deleteUser(String userId);
 }

--- a/src/main/java/com/cag/cagbackendapi/services/user/impl/UserService.java
+++ b/src/main/java/com/cag/cagbackendapi/services/user/impl/UserService.java
@@ -3,6 +3,7 @@ import com.cag.cagbackendapi.constants.DetailedErrorMessages;
 import com.cag.cagbackendapi.daos.impl.UserDao;
 import com.cag.cagbackendapi.dtos.UserRegistrationDto;
 import com.cag.cagbackendapi.dtos.UserDto;
+import com.cag.cagbackendapi.dtos.UserUpdateDto;
 import com.cag.cagbackendapi.errors.exceptions.BadRequestException;
 import com.cag.cagbackendapi.errors.exceptions.NotFoundException;
 import com.cag.cagbackendapi.services.user.UserServiceI;
@@ -42,12 +43,12 @@ public class UserService implements UserServiceI {
     }
 
     @Override
-    public UserDto updateUser(String userId, UserDto userRequestDto) {
+    public UserDto updateUser(String userId, UserUpdateDto userUpdateDto) {
         UUID userUUID = getUserUuidFromString(userId);
 
-        validateUserDto(userRequestDto);
+        validateUserUpdateDto(userUpdateDto);
 
-        var userResponseDto = userDao.updateUser(userUUID, userRequestDto);
+        var userResponseDto = userDao.updateUser(userUUID, userUpdateDto);
 
         if (userResponseDto == null) {
             throw new NotFoundException(DetailedErrorMessages.USER_NOT_FOUND, null);
@@ -69,7 +70,7 @@ public class UserService implements UserServiceI {
         return userResponseDto;
     }
 
-    private void validateUserDto(UserDto userDto) {
+    private void validateUserUpdateDto(UserUpdateDto userDto) {
         var badRequestMsg = "";
 
         if (userDto.getFirst_name() == null || userDto.getFirst_name().isBlank()) {
@@ -82,10 +83,6 @@ public class UserService implements UserServiceI {
 
         if (userDto.getEmail() == null || userDto.getEmail().isBlank()) {
             badRequestMsg += DetailedErrorMessages.EMAIL_REQUIRED;
-        }
-
-        if (userDto.getAgreed_18() == null || !userDto.getAgreed_18()) {
-            badRequestMsg += DetailedErrorMessages.MUST_BE_18;
         }
 
         if (!badRequestMsg.isEmpty()) {

--- a/src/test/java/com/cag/cagbackendapi/controllers/UserControllerTest.kt
+++ b/src/test/java/com/cag/cagbackendapi/controllers/UserControllerTest.kt
@@ -4,6 +4,7 @@ import com.cag.cagbackendapi.constants.DetailedErrorMessages
 import com.cag.cagbackendapi.constants.RestErrorMessages
 import com.cag.cagbackendapi.dtos.UserDto
 import com.cag.cagbackendapi.dtos.UserRegistrationDto
+import com.cag.cagbackendapi.dtos.UserUpdateDto
 import com.cag.cagbackendapi.errors.exceptions.UnauthorizedException
 import com.cag.cagbackendapi.errors.exceptions.BadRequestException
 import com.cag.cagbackendapi.errors.exceptions.NotFoundException
@@ -89,7 +90,7 @@ class UserControllerTest {
         val testAuthKey = "testAuthKey"
         val randomUUID = UUID.randomUUID()
         val randomUuidStr = randomUUID.toString()
-        val updateUser = UserDto(user_id = randomUUID, first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val updateUser = UserUpdateDto(first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com")
         val resultUpdateUser = UserDto(user_id = randomUUID, first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
 
         doNothing().whenever(validationService).validateAuthKey(testAuthKey)
@@ -106,7 +107,7 @@ class UserControllerTest {
     @Test
     fun updateUser_missingUserId_returns400(){
         val testAuthKey = "testAuthKey"
-        val updateUser = UserDto(user_id = null, first_name = "depaul", last_name = "sports", email = "depaulsports@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val updateUser = UserUpdateDto(first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com")
 
         val badRequestException = BadRequestException(DetailedErrorMessages.INVALID_UUID, null)
 
@@ -126,7 +127,7 @@ class UserControllerTest {
         val testAuthKey = ""
         val randomUUID = UUID.randomUUID()
         val randomUuidStr = randomUUID.toString()
-        val updateUser = UserDto(user_id = randomUUID, first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val updateUser = UserUpdateDto(first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com")
 
         val unauthorizedException = UnauthorizedException(DetailedErrorMessages.INVALID_UUID, null)
 
@@ -148,7 +149,7 @@ class UserControllerTest {
         val testAuthKey = "testAuthKey"
         val randomUUID = UUID.randomUUID()
         val randomUuidStr = randomUUID.toString()
-        val updateUser = UserDto(user_id = randomUUID, first_name = "DePaul", last_name = "sports", email = "depaulsports@gmail.com", active_status = true, img_url = null, agreed_18 = true, session_id = null)
+        val updateUser = UserUpdateDto(first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com")
 
         val notFoundException = NotFoundException(DetailedErrorMessages.USER_NOT_FOUND, null)
 

--- a/src/test/java/com/cag/cagbackendapi/integration/UserControllerIntegrationTests.kt
+++ b/src/test/java/com/cag/cagbackendapi/integration/UserControllerIntegrationTests.kt
@@ -4,6 +4,7 @@ import com.cag.cagbackendapi.constants.DetailedErrorMessages
 import com.cag.cagbackendapi.constants.RestErrorMessages
 import com.cag.cagbackendapi.dtos.UserRegistrationDto
 import com.cag.cagbackendapi.dtos.UserDto
+import com.cag.cagbackendapi.dtos.UserUpdateDto
 import com.cag.cagbackendapi.errors.ErrorDetails
 import com.cag.cagbackendapi.util.SpringCommandLineProfileResolver
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -150,12 +151,12 @@ class UserControllerIntegrationTests {
         val createUser = objectMapper.readValue(createdUserResponse.body, UserDto::class.java)
         val userId = createUser.user_id
 
-        val validUpdateUser = UserDto(user_id = userId, first_name = "Tony", last_name = "Stark", email="tstark@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val validUpdateUser = UserUpdateDto(first_name = "Tony", last_name = "Stark", email="tstark@gmail.com")
         val headers2 = HttpHeaders()
         headers2.set("authKey", validAuthKey)
         val request2 = HttpEntity(validUpdateUser, headers2)
 
-        val updateUserResponse = testRestTemplate.exchange("/user/${validUpdateUser.user_id.toString()}", HttpMethod.PUT, request2, String::class.java)
+        val updateUserResponse = testRestTemplate.exchange("/user/$userId", HttpMethod.PUT, request2, String::class.java)
         val updatedUser = objectMapper.readValue(updateUserResponse.body, UserDto::class.java)
 
         //test created user
@@ -172,13 +173,13 @@ class UserControllerIntegrationTests {
         assertEquals(validUpdateUser.first_name, updatedUser.first_name)
         assertEquals(validUpdateUser.last_name, updatedUser.last_name)
         assertEquals(validUpdateUser.email, updatedUser.email)
-        assertNotNull(validUpdateUser.user_id)
+        assertNotNull(userId)
     }
 
     @Test
     fun updateUser_invalidUserId_400BadRequest() {
         val userId = "blah"
-        val invalidUpdateUser = UserDto(null, first_name = "Tony", last_name = "Stark", email="tstark@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val invalidUpdateUser = UserUpdateDto(first_name = "Tony", last_name = "Stark", email="tstark@gmail.com")
         val headers2 = HttpHeaders()
         headers2.set("authKey", validAuthKey)
         val request2 = HttpEntity(invalidUpdateUser, headers2)
@@ -193,7 +194,7 @@ class UserControllerIntegrationTests {
 
     @Test
     fun updateUser_missingUserId_404NotFound() {
-        val invalidUpdateUser = UserDto(null, first_name = "Tony", last_name = "Stark", email="tstark@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val invalidUpdateUser = UserUpdateDto(first_name = "Tony", last_name = "Stark", email="tstark@gmail.com")
         val headers2 = HttpHeaders()
         headers2.set("authKey", validAuthKey)
         val request2 = HttpEntity(invalidUpdateUser, headers2)
@@ -214,7 +215,7 @@ class UserControllerIntegrationTests {
         val createUser = objectMapper.readValue(createdUserResponse.body, UserDto::class.java)
         val userId = createUser.user_id
 
-        val validUpdateUser = UserDto(user_id = userId, first_name = "Tony", last_name = "Stark", email="tstark@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val validUpdateUser = UserUpdateDto(first_name = "Tony", last_name = "Stark", email="tstark@gmail.com")
         val headers2 = HttpHeaders()
         headers2.set("authKey", "invalidAuthKey")
         val request2 = HttpEntity(validUpdateUser, headers2)
@@ -229,12 +230,13 @@ class UserControllerIntegrationTests {
 
     @Test
     fun updateUser_userNotFound_404NotFound(){
-        val validUpdateUser = UserDto(user_id = UUID.randomUUID(), first_name = "Tony", last_name = "Stark", email="tstark@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val userId = UUID.randomUUID()
+        val validUpdateUser = UserUpdateDto(first_name = "Tony", last_name = "Stark", email="tstark@gmail.com")
         val headers2 = HttpHeaders()
         headers2.set("authKey", validAuthKey)
         val request2 = HttpEntity(validUpdateUser, headers2)
 
-        val errorDetailsResponse = testRestTemplate.exchange("/user/${validUpdateUser.user_id.toString()}", HttpMethod.PUT, request2, ErrorDetails::class.java)
+        val errorDetailsResponse = testRestTemplate.exchange("/user/$userId", HttpMethod.PUT, request2, ErrorDetails::class.java)
 
         assertEquals(HttpStatus.NOT_FOUND, errorDetailsResponse.statusCode)
         assertNotNull(errorDetailsResponse?.body?.time)

--- a/src/test/java/com/cag/cagbackendapi/services/user/UserServiceTest.kt
+++ b/src/test/java/com/cag/cagbackendapi/services/user/UserServiceTest.kt
@@ -5,6 +5,7 @@ import com.cag.cagbackendapi.constants.RestErrorMessages
 import com.cag.cagbackendapi.daos.impl.UserDao
 import com.cag.cagbackendapi.dtos.UserRegistrationDto
 import com.cag.cagbackendapi.dtos.UserDto
+import com.cag.cagbackendapi.dtos.UserUpdateDto
 import com.cag.cagbackendapi.errors.exceptions.BadRequestException
 import com.cag.cagbackendapi.errors.exceptions.InternalServerErrorException
 import com.cag.cagbackendapi.errors.exceptions.NotFoundException
@@ -158,7 +159,7 @@ class UserServiceTest {
         //assemble
         val userUuid = UUID.randomUUID()
         val userId = userUuid.toString()
-        val updateUser = UserDto(user_id = userUuid, first_name = "Captain", last_name = "America", email = "capamerica@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val updateUser = UserUpdateDto(first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com")
         val resultUser = UserDto(user_id = userUuid, first_name = "Captain", last_name = "America", email = "capamerica@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
 
         whenever(userDao.updateUser(userUuid, updateUser)).thenReturn(resultUser)
@@ -175,7 +176,7 @@ class UserServiceTest {
         //assemble
         val userUuid = UUID.randomUUID()
         val userId = userUuid.toString()
-        val updateUser = UserDto(user_id = userUuid, first_name = "", last_name = null, email = "", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val updateUser = UserUpdateDto(first_name = "", last_name = null, email = "")
         val badRequestException = BadRequestException(DetailedErrorMessages.FIRST_NAME_REQUIRED + DetailedErrorMessages.LAST_NAME_REQUIRED + DetailedErrorMessages.EMAIL_REQUIRED, null)
 
         //act
@@ -191,7 +192,7 @@ class UserServiceTest {
     @Test
     fun updateUser_missingUserId_BadRequest(){
         //assemble
-        val updateUser = UserDto(user_id = null, first_name = "Tony", last_name = "Stark", email = "tstark@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val updateUser = UserUpdateDto(first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com")
         val badRequestException = BadRequestException(DetailedErrorMessages.INVALID_USER_ID, null)
 
         //act
@@ -209,7 +210,7 @@ class UserServiceTest {
         //assemble
         val userUuid = UUID.randomUUID()
         val userId = userUuid.toString()
-        val updateUser = UserDto(user_id = userUuid, first_name = "Tony", last_name = "Stark", email = "tstark@gmail.com", active_status = true, session_id = null, img_url = null, agreed_18 = true)
+        val updateUser = UserUpdateDto(first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com")
         val notFoundException = NotFoundException(DetailedErrorMessages.USER_NOT_FOUND, null)
 
         whenever(userDao.updateUser(userUuid, updateUser)).thenReturn(null)
@@ -231,7 +232,7 @@ class UserServiceTest {
         // assemble
         val userUuid = UUID.randomUUID()
         val userId = userUuid.toString()
-        val updateUser = UserDto(user_id = userUuid, first_name = "Tony", last_name = "Stark", email = "tstark@gmail.com", session_id = null, active_status = true, agreed_18 = true, img_url = null)
+        val updateUser = UserUpdateDto(first_name = "DePaul", last_name = "sports", email="depaulSports@gmail.com")
         val internalServerError = InternalServerErrorException(RestErrorMessages.INTERNAL_SERVER_ERROR_MESSAGE, null)
 
         whenever(userDao.updateUser(userUuid, updateUser)).thenThrow(internalServerError)


### PR DESCRIPTION
I noticed in our swagger that when we take the generic UserDto as input to our UpdateUser endpoint - it allows the user to enter info we don't want them to be able to enter. So I created a Dto specifically for updating the user to resolve this problem.