### PR TITLE
Fixed active status bug

### DIFF
--- a/src/main/java/com/cag/cagbackendapi/daos/impl/UserDao.kt
+++ b/src/main/java/com/cag/cagbackendapi/daos/impl/UserDao.kt
@@ -30,7 +30,20 @@ class UserDao : UserDaoI {
     override fun saveUser(userRegistrationDto: UserRegistrationDto): UserDto {
         logger.info(LOG_SAVE_USER(userRegistrationDto))
 
-        val savedUserEntity = userRepository.save(userDtoToEntity(userRegistrationDto))
+        val userEntity = UserEntity(
+            userId = null,
+            first_name = userRegistrationDto.first_name,
+            last_name = userRegistrationDto.last_name,
+            email = userRegistrationDto.email,
+            pass = userRegistrationDto.pass,
+            active_status = true,
+            session_id = null,
+            img_url = null,
+            agreed_18 = userRegistrationDto.agreed_18,
+            agreed_privacy = userRegistrationDto.agreed_privacy
+        )
+
+        val savedUserEntity = userRepository.save(userEntity)
         return savedUserEntity.toDto()
     }
 
@@ -61,9 +74,5 @@ class UserDao : UserDaoI {
         val deleteUserEntity = userRepository.getByUserId(userUUID) ?: return null
         userRepository.deleteById(userUUID)
         return deleteUserEntity.toDto()
-    }
-
-    private fun userDtoToEntity(userRegistrationDto: UserRegistrationDto): UserEntity {
-        return objectMapper.convertValue(userRegistrationDto, UserEntity::class.java)
     }
 }

--- a/src/test/java/com/cag/cagbackendapi/integration/UserControllerIntegrationTests.kt
+++ b/src/test/java/com/cag/cagbackendapi/integration/UserControllerIntegrationTests.kt
@@ -32,6 +32,8 @@ class UserControllerIntegrationTests {
 
     @Test
     fun registerUser_validInput_201Success() {
+        val expectedActiveStatus = true
+
         val headers = HttpHeaders()
         headers.set("authKey", validAuthKey)
         val request = HttpEntity(validRegisterUser, headers)
@@ -44,6 +46,9 @@ class UserControllerIntegrationTests {
         assertEquals(validRegisterUser.first_name, createUser.first_name)
         assertEquals(validRegisterUser.last_name, createUser.last_name)
         assertEquals(validRegisterUser.email, createUser.email)
+        assertEquals(expectedActiveStatus, createUser.active_status)
+        assertEquals(validRegisterUser.agreed_privacy, createUser.agreed_privacy)
+        assertEquals(validRegisterUser.agreed_18, createUser.agreed_18)
         assertNotNull(createUser.userId)
     }
 

--- a/src/test/java/com/cag/cagbackendapi/integration/UserControllerIntegrationTests.kt
+++ b/src/test/java/com/cag/cagbackendapi/integration/UserControllerIntegrationTests.kt
@@ -268,6 +268,8 @@ class UserControllerIntegrationTests {
 
     @Test
     fun getUser_validInput_200Success() {
+        val expectedActiveStatus = true
+
         val headers = HttpHeaders()
         headers.set("authKey", validAuthKey)
         val request = HttpEntity(validRegisterUser, headers)
@@ -287,6 +289,9 @@ class UserControllerIntegrationTests {
         assertEquals(HttpStatus.OK, getUserResponse.statusCode)
         assertEquals(validRegisterUser.first_name, getUser.first_name)
         assertEquals(validRegisterUser.email, getUser.email)
+        assertEquals(expectedActiveStatus, createUser.active_status)
+        assertEquals(validRegisterUser.agreed_privacy, createUser.agreed_privacy)
+        assertEquals(validRegisterUser.agreed_18, createUser.agreed_18)
         assertNotNull(getUser.userId)
     }
 


### PR DESCRIPTION
Fixed active status! It was my object mapping thing I showed you guys how to use. When we map the UserRegistrationDto to a UserEntity - it defaults active status to null because we don't provide it on the UserRegistrationDto. Then it sends null to the database, but our table is smart enough to know that it should default to active status = true - so it does. But then Spring returns back to us the original entity that had active status null - not the record in the database like I thought it should return to us.