### PR TITLE
Refactored profile validation error handling

### DIFF
--- a/src/test/java/com/cag/cagbackendapi/integration/ProfileControllerIntegrationTests.kt
+++ b/src/test/java/com/cag/cagbackendapi/integration/ProfileControllerIntegrationTests.kt
@@ -159,23 +159,14 @@ class ProfileControllerIntegrationTests {
         //register profile headers
         val headers2 = HttpHeaders()
         headers2.set("authKey", validAuthKey)
-        headers2.set("userId", userIdUUID.toString())
         val request2 = HttpEntity(validRegisterProfile, headers2)
-
 
         //create profile
         val userProfileResponse = testRestTemplate.exchange("/user/${userIdUUID.toString()}/profile/register", HttpMethod.POST, request2, String::class.java)
         val createdProfile = objectMapper.readValue(userProfileResponse.body, ProfileDto::class.java)
 
-        //register profile headers2
-        val headers3 = HttpHeaders()
-        headers3.set("authKey", validAuthKey)
-        headers3.set("userId", userIdUUID.toString())
-        val request3 = HttpEntity(validRegisterProfile, headers3)
-
         //Error create duplicate profile
-        val errorDetailsResponse = testRestTemplate.exchange("/user/${userIdUUID.toString()}/profile/register", HttpMethod.POST, request3, ErrorDetails::class.java)
-
+        val errorDetailsResponse = testRestTemplate.exchange("/user/${userIdUUID.toString()}/profile/register", HttpMethod.POST, request2, ErrorDetails::class.java)
 
         //check the created user
         assertNotNull(createdUserResponse)
@@ -307,7 +298,7 @@ class ProfileControllerIntegrationTests {
     }
 
     @Test
-    fun registerProfile_invalidUnionStatus_404UnionNotValid() {
+    fun registerProfile_invalidUnionStatus_400InvalidUnion() {
         //create user headers
         val headers = HttpHeaders()
         headers.set("authKey", validAuthKey)
@@ -336,9 +327,9 @@ class ProfileControllerIntegrationTests {
         assertNotNull(createUser.userId)
 
         //check the error
-        assertEquals(HttpStatus.NOT_FOUND, errorDetailsResponse.statusCode)
+        assertEquals(HttpStatus.BAD_REQUEST, errorDetailsResponse.statusCode)
         assertNotNull(errorDetailsResponse?.body?.time)
-        assertEquals(errorDetailsResponse?.body?.restErrorMessage, RestErrorMessages.NOT_FOUND_MESSAGE)
+        assertEquals(errorDetailsResponse?.body?.restErrorMessage, RestErrorMessages.BAD_REQUEST_MESSAGE)
         assertEquals(errorDetailsResponse?.body?.detailedMessage, DetailedErrorMessages.UNION_STATUS_NOT_SUPPORTED)
     }
 


### PR DESCRIPTION
Previously, if someone provided an invalid Union Status we would still create a profile. Now we don't create the profile until after we validate the union status