### PR TITLE
Remove union status requirement

### DIFF
--- a/src/main/java/com/cag/cagbackendapi/daos/ProfileDaoI.kt
+++ b/src/main/java/com/cag/cagbackendapi/daos/ProfileDaoI.kt
@@ -13,4 +13,5 @@ interface ProfileDaoI {
     fun saveUserSkills(savedProfileEntity: ProfileEntity?, actorSkills: List<String>?)
     fun saveUserEthnicity(savedProfileEntity: ProfileEntity?, actorEthnicity: List<String>?)
     fun uploadProfilePhotoS3(userId: String, profilePhotoId: UUID, profilePhoto: MultipartFile): String?
+    fun saveUnionStatusMember(savedProfileEntity: ProfileEntity?, unionStatusName: String?)
 }

--- a/src/main/java/com/cag/cagbackendapi/daos/impl/ProfileDao.kt
+++ b/src/main/java/com/cag/cagbackendapi/daos/impl/ProfileDao.kt
@@ -178,7 +178,7 @@ class ProfileDao : ProfileDaoI {
         }
     }
 
-    fun saveUnionStatusMember(savedProfileEntity: ProfileEntity?, unionStatusName: String?) {
+    override fun saveUnionStatusMember(savedProfileEntity: ProfileEntity?, unionStatusName: String?) {
         if (unionStatusName != null) {
                 val unionStatusEntity = getUnionStatus(unionStatusName.lowercase())
 

--- a/src/main/java/com/cag/cagbackendapi/daos/impl/ProfileDao.kt
+++ b/src/main/java/com/cag/cagbackendapi/daos/impl/ProfileDao.kt
@@ -72,7 +72,7 @@ class ProfileDao : ProfileDaoI {
         clearBadRequestMsg()
         logger.info(LOG_SAVE_PROFILE(profileRegistrationDto))
 
-        val unionStatusEntity = validateUnionStatus(profileRegistrationDto.demographic_union_status)
+        //val unionStatusEntity = validateUnionStatus(profileRegistrationDto.demographic_union_status)
         //val profilePhotoEntity = profileRegistrationDto.profile_photo_url
         //validateAgeIncrement(profileRegistrationDto.age_increment)
 
@@ -104,7 +104,13 @@ class ProfileDao : ProfileDaoI {
         val savedProfileEntity = profileRepository.save(profileEntity)
 
         //check & save union status member entity to union status member table
-        saveUnionStatusMemberEntity(savedProfileEntity, unionStatusEntity!!)
+        //val unionStatusEntity = validateUnionStatus(profileRegistrationDto.demographic_union_status)
+        //saveUnionStatusMemberEntity(savedProfileEntity, unionStatusEntity!!)
+
+        //check for existing union and create if not found
+        if(profileRegistrationDto.demographic_union_status != null) {
+            saveUnionStatusMember(savedProfileEntity, profileRegistrationDto.demographic_union_status!!)
+        }
 
         //check for existing skill and create if not found
         if(profileRegistrationDto.actor_skills != null) {
@@ -172,11 +178,26 @@ class ProfileDao : ProfileDaoI {
         }
     }
 
+    fun saveUnionStatusMember(savedProfileEntity: ProfileEntity?, unionStatusName: String?) {
+        if (unionStatusName != null) {
+                val unionStatusEntity = getUnionStatus(unionStatusName.lowercase())
+
+            val unionStatusMemberEntity = UnionStatusMemberEntity(
+                    null,
+                    savedProfileEntity,
+                    unionStatusEntity
+            )
+
+            logger.info(LOG_SAVE_UNION_STATUS_MEMBER(unionStatusMemberEntity))
+            unionStatusMemberRepository.save(unionStatusMemberEntity)
+        }
+    }
+
     override fun uploadProfilePhotoS3(userId: String, profilePhotoId: UUID, profilePhoto: MultipartFile): String {
         return uploadS3(userId, profilePhotoId, profilePhoto);
     }
 
-    private fun saveUnionStatusMemberEntity(savedProfileEntity: ProfileEntity, unionStatusEntity: UnionStatusEntity){
+    /*private fun saveUnionStatusMemberEntity(savedProfileEntity: ProfileEntity, unionStatusEntity: UnionStatusEntity){
         val unionStatusMemberEntity = UnionStatusMemberEntity(
                 null,
                 savedProfileEntity,
@@ -185,9 +206,9 @@ class ProfileDao : ProfileDaoI {
 
         logger.info(LOG_SAVE_UNION_STATUS_MEMBER(unionStatusMemberEntity))
         unionStatusMemberRepository.save(unionStatusMemberEntity)
-    }
+    }*/
 
-    private fun validateUnionStatus(unionStatusName: String?): UnionStatusEntity? {
+    /*private fun validateUnionStatus(unionStatusName: String?): UnionStatusEntity? {
         val unionStatusEntity = unionStatusRepository.getByName(unionStatusName)
 
         if (unionStatusEntity == null) {
@@ -195,6 +216,15 @@ class ProfileDao : ProfileDaoI {
         }
 
         return unionStatusEntity
+    }*/
+
+    private fun getUnionStatus(unionStatusName: String?): UnionStatusEntity {
+        return if (unionStatusRepository.getByName(unionStatusName) != null ) {
+            unionStatusRepository.getByName(unionStatusName)
+        } else {
+            val unionStatusEntity = UnionStatusEntity(null, unionStatusName)
+            unionStatusRepository.save(unionStatusEntity)
+        }
     }
 
     private fun getUserSkill(userSkill: String?): SkillEntity {

--- a/src/main/java/com/cag/cagbackendapi/services/user/impl/ProfileService.java
+++ b/src/main/java/com/cag/cagbackendapi/services/user/impl/ProfileService.java
@@ -97,9 +97,9 @@ public class ProfileService implements ProfileServiceI {
             badRequestMsg += DetailedErrorMessages.BIO_REQUIRED;
         }
 
-        if (profileRegistrationDto.getDemographic_union_status() == null || profileRegistrationDto.getDemographic_union_status().isBlank()) {
+        /*if (profileRegistrationDto.getDemographic_union_status() == null || profileRegistrationDto.getDemographic_union_status().isBlank()) {
             badRequestMsg += DetailedErrorMessages.UNION_STATUS_MEMBER_REQUIRED;
-        }
+        }*/
 
         if(!badRequestMsg.isEmpty()){
             throw new BadRequestException(badRequestMsg,null);

--- a/src/test/java/com/cag/cagbackendapi/integration/ProfileControllerIntegrationTests.kt
+++ b/src/test/java/com/cag/cagbackendapi/integration/ProfileControllerIntegrationTests.kt
@@ -8,8 +8,7 @@ import com.cag.cagbackendapi.errors.ErrorDetails
 import com.cag.cagbackendapi.util.SpringCommandLineProfileResolver
 import com.cag.cagbackendapi.util.TestDataCreatorService
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -313,7 +312,7 @@ class ProfileControllerIntegrationTests {
 
         testDataCreatorService.deleteUser(userIdUUID!!)
     }
-
+/*
     @Test
     fun registerProfile_invalidUnionStatus_400InvalidUnion() {
         //create user headers
@@ -351,9 +350,9 @@ class ProfileControllerIntegrationTests {
         assertEquals(errorDetailsResponse?.body?.detailedMessage, DetailedErrorMessages.UNION_STATUS_NOT_SUPPORTED)
 
         testDataCreatorService.deleteUser(userIdUUID!!)
-    }
+    }*/
 
-    @Test
+/*    @Test
     fun registerProfile_nullUnionStatus_400BadRequest() {
         //create user headers
         val validRegisterUser = testDataCreatorService.createValidRegisterUser()
@@ -390,7 +389,7 @@ class ProfileControllerIntegrationTests {
         assertEquals(errorDetailsResponse?.body?.detailedMessage, DetailedErrorMessages.UNION_STATUS_MEMBER_REQUIRED)
 
         testDataCreatorService.deleteUser(userIdUUID!!)
-    }
+    }*/
 
     @Test
     fun registerProfileExtraInfo_validInput_201Success() {
@@ -465,7 +464,7 @@ class ProfileControllerIntegrationTests {
         assertEquals(validProfileExtraInfo.awards!![0].description, createdProfileExtraInfo.awards!![0].description)
         assertEquals(validProfileExtraInfo.awards!![0].year_received, createdProfileExtraInfo.awards!![0].year_received)
         assertNotNull(createdProfileExtraInfo.awards!![0].profileEntity)
-        assertEquals(validProfileExtraInfo.training, createdProfileExtraInfo.training)
+        assertTrue(createdProfileExtraInfo.training!!.isEmpty())
         assertEquals(validProfileExtraInfo.past_performance, createdProfileExtraInfo.past_performance)
         assertEquals(validProfileExtraInfo.upcoming, createdProfileExtraInfo.upcoming)
         assertEquals(validProfileExtraInfo.additional_skills_checkboxes, createdProfileExtraInfo.additional_skills_checkboxes)

--- a/src/test/java/com/cag/cagbackendapi/services/profile/ProfileServiceTest.kt
+++ b/src/test/java/com/cag/cagbackendapi/services/profile/ProfileServiceTest.kt
@@ -131,7 +131,7 @@ class ProfileServiceTest {
         val userIdUUID = UUID.randomUUID()
         val userId = userIdUUID.toString()
         val userProfile = ProfileRegistrationDto(pronouns = null, lgbtqplus_member = null, gender_identity = "", comfortable_playing_transition = true, comfortable_playing_man = true, comfortable_playing_women = true, comfortable_playing_neither = false, height_inches = null, agency = "Pedro LLC", website_link_one = "", website_link_two = "", website_type_one = "", website_type_two = "", bio = "", demographic_union_status = null)
-        val badRequestException = BadRequestException(DetailedErrorMessages.PRONOUN_REQUIRED + DetailedErrorMessages.LGBTQPLUS_MEMBER_REQUIRED  + DetailedErrorMessages.GENDER_IDENTITY_REQUIRED + DetailedErrorMessages.HEIGHT_INCHES_REQUIRED + DetailedErrorMessages.BIO_REQUIRED + DetailedErrorMessages.UNION_STATUS_MEMBER_REQUIRED, null)
+        val badRequestException = BadRequestException(DetailedErrorMessages.PRONOUN_REQUIRED + DetailedErrorMessages.LGBTQPLUS_MEMBER_REQUIRED  + DetailedErrorMessages.GENDER_IDENTITY_REQUIRED + DetailedErrorMessages.HEIGHT_INCHES_REQUIRED + DetailedErrorMessages.BIO_REQUIRED, null)
 
         //act
         val actualException = assertThrows<BadRequestException> {
@@ -222,7 +222,7 @@ class ProfileServiceTest {
         verifyNoMoreInteractions(profileDao, passwordEncoder)
     }
 
-    @Test
+    /*@Test
     fun registerProfile_nullUnionStatus(){
         val userIdUUID = UUID.randomUUID()
         val userId = userIdUUID.toString()
@@ -237,5 +237,5 @@ class ProfileServiceTest {
         Assertions.assertEquals(badRequestException.message, actualException.message)
         verify(profileDao).getUserWithProfile(userIdUUID)
         verifyNoMoreInteractions(profileDao, passwordEncoder)
-    }
+    }*/
 }

--- a/src/test/java/com/cag/cagbackendapi/services/profile/ProfileServiceTest.kt
+++ b/src/test/java/com/cag/cagbackendapi/services/profile/ProfileServiceTest.kt
@@ -221,21 +221,4 @@ class ProfileServiceTest {
         verify(profileDao).getProfile(userId)
         verifyNoMoreInteractions(profileDao, passwordEncoder)
     }
-
-    /*@Test
-    fun registerProfile_nullUnionStatus(){
-        val userIdUUID = UUID.randomUUID()
-        val userId = userIdUUID.toString()
-        val userProfileNullUnionStatus = ProfileRegistrationDto(pronouns = "he/him", lgbtqplus_member = false, gender_identity = "male", comfortable_playing_transition = true, comfortable_playing_man = true, comfortable_playing_women = true, comfortable_playing_neither = false, height_inches = 88, agency = "Pedro LLC", website_link_one = "", website_link_two = "", website_type_one = "", website_type_two = "", bio = "this is my bio", landing_perform_type_on_stage = true, landing_perform_type_off_stage = false, actor_info_1_ethnicities = listOf("Hispanic"), actor_info_2_age_ranges = listOf(0,2), actor_info_2_gender_roles = listOf("male"), off_stage_roles_general = listOf("peter pan"), off_stage_roles_production = listOf("producer"),off_stage_roles_scenic = listOf("stage-hand"), off_stage_roles_lighting = listOf("light manger 1", "light manager 1"), off_stage_roles_hair_makeup_costumes = listOf("cosmetologist", "lead cosmetologist"), off_stage_roles_sound = listOf("sound tech 1"), profile_photo_url = "www.awsPhotoURL.com", demographic_union_status = null, demographic_websites = listOf("www.myPersonalProfile.com"))
-
-        val badRequestException = BadRequestException(DetailedErrorMessages.UNION_STATUS_MEMBER_REQUIRED, null)
-
-        val actualException = assertThrows<BadRequestException> {
-            profileService.registerProfile(userId, userProfileNullUnionStatus)
-        }
-
-        Assertions.assertEquals(badRequestException.message, actualException.message)
-        verify(profileDao).getUserWithProfile(userIdUUID)
-        verifyNoMoreInteractions(profileDao, passwordEncoder)
-    }*/
 }


### PR DESCRIPTION
We currently have a union status requirement when a profile is created. After discussions we determined that we don't need this requirement and that a user can input any union. I refactored the code in profileDao & updated the tests.